### PR TITLE
replace pkg_resources with importlib.metadata for setuptools 71+ comp…

### DIFF
--- a/isbntools/contrib/modules/report/_audit.py
+++ b/isbntools/contrib/modules/report/_audit.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 """Performs an audit and reports on installed scripts and plugins."""
 
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points as _entry_points
+
+
+def iter_entry_points(group):
+    return _entry_points(group=group)
 
 from ._columnize import columnize
 


### PR DESCRIPTION
…atibility

`pkg_resources` (from `setuptools`) was removed in setuptools 71+, causing
an import error that breaks all isbntools CLI commands on affected systems.

Changes proposed in this pull request:

- Replace `from pkg_resources import iter_entry_points` with `importlib.metadata.entry_points`
- Add a local `iter_entry_points(group)` wrapper to keep call sites unchanged
- `importlib.metadata` is stdlib since Python 3.8, no new dependencies required

@xlcnd
